### PR TITLE
fix: add native support for void union variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,14 @@ The parser extracts typed values. What you do with them is your business.
 - **No custom types** — only built-in types and enums
 - **No nested slices** — slices of slices not supported (`[][]T`)
 - **Equals syntax only** — use `--name=value` not `--name value`
-- **No void union variants** — use `struct {}` for no-arg subcommands. see [Issue](https://github.com/atisans/flags.zig/issues/6)
+- **No void union variants** — use `struct {}` for subcommands with no flags:
+  ```zig
+  const CLI = union(enum) {
+      start: struct { port: u16 = 8080 },
+      stop: struct {},  // no flags, use struct{} instead of void
+  };
+  ```
+  See [Issue](https://github.com/atisans/flags.zig/issues/6)
 
 ## Credits
 This library draws significant inspiration from two exceptional projects:

--- a/README.md
+++ b/README.md
@@ -212,14 +212,6 @@ The parser extracts typed values. What you do with them is your business.
 - **No custom types** — only built-in types and enums
 - **No nested slices** — slices of slices not supported (`[][]T`)
 - **Equals syntax only** — use `--name=value` not `--name value`
-- **No void union variants** — use `struct {}` for subcommands with no flags:
-  ```zig
-  const CLI = union(enum) {
-      start: struct { port: u16 = 8080 },
-      stop: struct {},  // no flags, use struct{} instead of void
-  };
-  ```
-  See [Issue](https://github.com/atisans/flags.zig/issues/6)
 
 ## Credits
 This library draws significant inspiration from two exceptional projects:

--- a/src/flags.zig
+++ b/src/flags.zig
@@ -248,7 +248,8 @@ fn parse_subcommand(
             }
             break :blk try parse_commands(allocator, args, field.type);
         },
-        else => @compileError("subcommand types must be struct or union(enum)"),
+        .void => if (args.len > 0 and !is_help_arg(args[0])) error.UnexpectedArgument else {},
+        else => @compileError("subcommand types must be struct, union(enum), or void"),
     };
 }
 
@@ -498,6 +499,32 @@ test "parse subcommand with defaults" {
     const result = try parse(allocator, &.{ "prog", "start" }, CLI);
     try std.testing.expect(std.mem.eql(u8, result.start.host, "localhost"));
     try std.testing.expect(result.start.port == 8080);
+}
+
+test "void subcommand variant" {
+    const allocator = std.testing.allocator;
+    const CLI = union(enum) {
+        start: struct {
+            port: u16 = 8080,
+        },
+        stop: void,
+    };
+
+    const result = try parse(allocator, &.{ "prog", "stop" }, CLI);
+    try std.testing.expect(result == .stop);
+
+    const result2 = try parse(allocator, &.{ "prog", "start" }, CLI);
+    try std.testing.expect(result2.start.port == 8080);
+}
+
+test "void subcommand variant with extra args" {
+    const allocator = std.testing.allocator;
+    const CLI = union(enum) {
+        start: struct { port: u16 = 8080 },
+        stop: void,
+    };
+
+    try std.testing.expectError(error.UnexpectedArgument, parse(allocator, &.{ "prog", "stop", "--force" }, CLI));
 }
 
 test "missing subcommand" {

--- a/src/flags.zig
+++ b/src/flags.zig
@@ -153,17 +153,13 @@ fn parse_struct(allocator: std.mem.Allocator, args: []const []const u8, comptime
 
         if (positional_index >= positional_fields.len) return error.TooManyPositionals;
 
-        var matched = false;
         inline for (positional_fields, 0..) |field, pi| {
             if (pi == positional_index) {
                 @field(result, field.name) = try parse_value(field.type, arg);
-                matched = true;
             }
         }
-        if (matched) {
-            positional_index += 1;
-            positional_only = true;
-        }
+        positional_index += 1;
+        positional_only = true;
     }
 
     // Build slices and apply defaults.

--- a/src/flags.zig
+++ b/src/flags.zig
@@ -637,7 +637,7 @@ test "slice repeated flags" {
     const result = try parse(allocator, &.{ "prog", "--files=a.txt", "--files=b.txt", "--files=c.txt" }, Args);
     defer allocator.free(result.files);
 
-    try std.testing.expectEqual(@as(usize, 3), result.files.len);
+    try std.testing.expectEqual(3, result.files.len);
     try std.testing.expect(std.mem.eql(u8, result.files[0], "a.txt"));
     try std.testing.expect(std.mem.eql(u8, result.files[1], "b.txt"));
     try std.testing.expect(std.mem.eql(u8, result.files[2], "c.txt"));
@@ -652,7 +652,7 @@ test "slice comma separated" {
     const result = try parse(allocator, &.{ "prog", "--files=a.txt,b.txt,c.txt" }, Args);
     defer allocator.free(result.files);
 
-    try std.testing.expectEqual(@as(usize, 3), result.files.len);
+    try std.testing.expectEqual(3, result.files.len);
     try std.testing.expect(std.mem.eql(u8, result.files[0], "a.txt"));
     try std.testing.expect(std.mem.eql(u8, result.files[1], "b.txt"));
     try std.testing.expect(std.mem.eql(u8, result.files[2], "c.txt"));
@@ -667,10 +667,10 @@ test "slice integer values" {
     const result = try parse(allocator, &.{ "prog", "--ports=8080", "--ports=9090", "--ports=3000" }, Args);
     defer allocator.free(result.ports);
 
-    try std.testing.expectEqual(@as(usize, 3), result.ports.len);
-    try std.testing.expectEqual(@as(u16, 8080), result.ports[0]);
-    try std.testing.expectEqual(@as(u16, 9090), result.ports[1]);
-    try std.testing.expectEqual(@as(u16, 3000), result.ports[2]);
+    try std.testing.expectEqual(3, result.ports.len);
+    try std.testing.expectEqual(8080, result.ports[0]);
+    try std.testing.expectEqual(9090, result.ports[1]);
+    try std.testing.expectEqual(3000, result.ports[2]);
 }
 
 test "slice enum values" {
@@ -683,7 +683,7 @@ test "slice enum values" {
     const result = try parse(allocator, &.{ "prog", "--formats=json,yaml,toml" }, Args);
     defer allocator.free(result.formats);
 
-    try std.testing.expectEqual(@as(usize, 3), result.formats.len);
+    try std.testing.expectEqual(3, result.formats.len);
     try std.testing.expectEqual(Format.json, result.formats[0]);
     try std.testing.expectEqual(Format.yaml, result.formats[1]);
     try std.testing.expectEqual(Format.toml, result.formats[2]);
@@ -697,7 +697,7 @@ test "slice with default" {
 
     const result = try parse(allocator, &.{"prog"}, Args);
     // Default is used (no allocation), nothing to free.
-    try std.testing.expectEqual(@as(usize, 0), result.files.len);
+    try std.testing.expectEqual(0, result.files.len);
 }
 
 test "slice mixed with scalar flags" {
@@ -711,11 +711,11 @@ test "slice mixed with scalar flags" {
     const result = try parse(allocator, &.{ "prog", "--files=a.txt", "--verbose", "--files=b.txt", "--port=3000" }, Args);
     defer allocator.free(result.files);
 
-    try std.testing.expectEqual(@as(usize, 2), result.files.len);
+    try std.testing.expectEqual(2, result.files.len);
     try std.testing.expect(std.mem.eql(u8, result.files[0], "a.txt"));
     try std.testing.expect(std.mem.eql(u8, result.files[1], "b.txt"));
     try std.testing.expect(result.verbose == true);
-    try std.testing.expectEqual(@as(u16, 3000), result.port);
+    try std.testing.expectEqual(3000, result.port);
 }
 
 test "slice comma separated integers" {
@@ -727,10 +727,10 @@ test "slice comma separated integers" {
     const result = try parse(allocator, &.{ "prog", "--ports=80,443,8080" }, Args);
     defer allocator.free(result.ports);
 
-    try std.testing.expectEqual(@as(usize, 3), result.ports.len);
-    try std.testing.expectEqual(@as(u16, 80), result.ports[0]);
-    try std.testing.expectEqual(@as(u16, 443), result.ports[1]);
-    try std.testing.expectEqual(@as(u16, 8080), result.ports[2]);
+    try std.testing.expectEqual(3, result.ports.len);
+    try std.testing.expectEqual(80, result.ports[0]);
+    try std.testing.expectEqual(443, result.ports[1]);
+    try std.testing.expectEqual(8080, result.ports[2]);
 }
 
 test "slice invalid element" {
@@ -751,7 +751,7 @@ test "slice single value" {
     const result = try parse(allocator, &.{ "prog", "--tags=only-one" }, Args);
     defer allocator.free(result.tags);
 
-    try std.testing.expectEqual(@as(usize, 1), result.tags.len);
+    try std.testing.expectEqual(1, result.tags.len);
     try std.testing.expect(std.mem.eql(u8, result.tags[0], "only-one"));
 }
 
@@ -766,12 +766,12 @@ test "multiple slice fields" {
     defer allocator.free(result.files);
     defer allocator.free(result.ports);
 
-    try std.testing.expectEqual(@as(usize, 2), result.files.len);
+    try std.testing.expectEqual(2, result.files.len);
     try std.testing.expect(std.mem.eql(u8, result.files[0], "a.txt"));
     try std.testing.expect(std.mem.eql(u8, result.files[1], "b.txt"));
-    try std.testing.expectEqual(@as(usize, 2), result.ports.len);
-    try std.testing.expectEqual(@as(u16, 80), result.ports[0]);
-    try std.testing.expectEqual(@as(u16, 443), result.ports[1]);
+    try std.testing.expectEqual(2, result.ports.len);
+    try std.testing.expectEqual(80, result.ports[0]);
+    try std.testing.expectEqual(443, result.ports[1]);
 }
 
 test "global flags with subcommand" {


### PR DESCRIPTION
- **Remove dead matched variable in positional parsing**
- **Remove redundant @as(usize, N) casts in test assertions**
- **Add code example for struct{} workaround in README**
- **fix: add native support for void union variants**
